### PR TITLE
Fix error undefined un view to create savings account

### DIFF
--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
@@ -227,9 +227,14 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
     return { charges: this.chargesDataSource };
   }
 
+  // get selectedClientMembers() {
+  //   return { selectedMembers: this.activeClientMembers.filter((item: any) => item.selected) };
+  // }
+
   get selectedClientMembers() {
-    return { selectedMembers: this.activeClientMembers.filter((item: any) => item.selected) };
+    return { selectedMembers: (this.activeClientMembers || []).filter((item: any) => item.selected) };
   }
+  
 
   /** Toggle all checks */
   toggleSelects() {


### PR DESCRIPTION
## Description

bug fix when generating a savings account, a list that is iterated without verification is causing a console error that did not allow the account creation to proceed.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
