### PR TITLE
[BELAT-1653] Create Keycloak User upon Client creation from Backoffice Portal

### DIFF
--- a/docs/BELAT/KEYCLOAK_USER_SYNC.md
+++ b/docs/BELAT/KEYCLOAK_USER_SYNC.md
@@ -1,17 +1,46 @@
 # Sincronización de Clientes a Keycloak
 
-Esta extensión permite mantener sincronizados los datos de los clientes entre Mifos (Fineract) y Keycloak. Cuando se actualiza la información de un cliente en la plataforma, los cambios se envían automáticamente a un servicio externo de sincronización para mantener la integridad de los perfiles en ambos sistemas.
+Esta extensión permite mantener sincronizados los datos de los clientes entre Mifos (Fineract) y Keycloak. Existen dos escenarios principales de sincronización: la creación de nuevos usuarios y la actualización de usuarios existentes.
 
-## Funcionamiento
+## Escenarios de Sincronización
 
-La sincronización se realiza de forma diferencial a través del servicio `UserSyncService`. El sistema captura un "snapshot" del estado original del cliente y lo compara con los nuevos datos del formulario, enviando únicamente los campos que han sido modificados (nombre, apellido, email, teléfono, etc.).
+La lógica de sincronización se centraliza en el servicio `UserSyncService`, el cual es invocado desde distintos módulos de la aplicación según la acción realizada.
 
-- **Servicio Interno:** `UserSyncService`
-- **Componente Integrado:** `EditClientComponent` (integrado en el flujo de guardado de edición de clientes).
+### 1. Creación de Clientes
+
+Cuando se registra un nuevo cliente en la plataforma, el sistema notifica automáticamente al servicio de sincronización para dar de alta al usuario en Keycloak e iniciar el flujo de bienvenida (verificación de email y establecimiento de contraseña).
+
+- **Componente:** `CreateClientComponent`
+- **Endpoint:** `POST /keycloak/create/user`
+- **Requerimientos de Campos:**
+  | Campo | Origen en Fineract | Requerido |
+  | :--- | :--- | :--- |
+  | `username` | `emailAddress` | Sí |
+  | `email` | `emailAddress` | Sí |
+  | `firstname` | `firstname` o `fullname` | Sí |
+  | `lastname` | `lastname` | Sí |
+  | `fineract_id` | `resourceId` (ID generado) | Sí |
+  | `country` | `tenantIdentifier` (Tenant activo) | Sí |
+  | `phone` | `mobileNo` | No |
+
+### 2. Actualización de Clientes
+
+Cuando se modifica la información de un cliente existente, el sistema realiza una sincronización diferencial. Captura un "snapshot" del estado original y lo compara con los nuevos datos, enviando únicamente los campos que han cambiado.
+
+- **Componente:** `EditClientComponent`
+- **Endpoint:** `POST /keycloak/update/user/{username}`
+- **Campos Sincronizados (Diferenciales):**
+  | Campo | Atributo Keycloak |
+  | :--- | :--- |
+  | `firstname` | `firstName` |
+  | `lastname` | `lastName` |
+  | `emailAddress` | `email` |
+  | `mobileNo` | `phone` |
+  | `externalId` | `external_id` |
 
 ## Variables de Configuración
 
-Para el correcto funcionamiento de esta extensión, se deben configurar las siguientes variables de entorno. En entornos de contenedores (Docker/Railway), se utiliza la convención de doble guion bajo (`__`) para representar la jerarquía:
+Para el correcto funcionamiento de esta extensión, se deben configurar las siguientes variables de entorno. Se utiliza la convención de doble guion bajo (`__`) para representar la jerarquía:
 
 | Variable                                                 | Descripción                                                                                      | Valor por Defecto |
 | :------------------------------------------------------- | :----------------------------------------------------------------------------------------------- | :---------------- |
@@ -20,4 +49,5 @@ Para el correcto funcionamiento de esta extensión, se deben configurar las sigu
 
 ## Consideraciones Técnicas
 
-- La sincronización solo se dispara si el campo `emailAddress` está presente, ya que se utiliza como identificador único en Keycloak.
+- **Validación:** En el escenario de creación, si falta algún campo obligatorio (todos excepto `phone`), la sincronización se omite y se registra un log de depuración.
+- **Identificador:** El campo `emailAddress` es fundamental en ambos escenarios, ya que se utiliza como identificador único para vincular las cuentas entre Mifos y Keycloak.

--- a/src/app/clients/create-client/create-client.component.ts
+++ b/src/app/clients/create-client/create-client.component.ts
@@ -155,7 +155,6 @@ export class CreateClientComponent {
     }
 
     this.clientsService.createClient(clientData).subscribe((response: any) => {
-      console.log('Create Client Response:', response);
       const country = this.settingsService.tenantIdentifier;
       this.userSyncService.createKeycloakUser(clientData, response.resourceId, country).subscribe();
       this.router.navigate(

--- a/src/app/clients/create-client/create-client.component.ts
+++ b/src/app/clients/create-client/create-client.component.ts
@@ -14,6 +14,7 @@ import { ClientDatatableStepComponent } from '../client-stepper/client-datatable
 /** Custom Services */
 import { SettingsService } from 'app/settings/settings.service';
 import { ClientIdentifiersStepComponent } from '../client-stepper/client-identifiers-step/client-identifiers-step.component';
+import { UserSyncService } from 'app/third-party/user-sync/user-sync.service';
 
 /**
  * Create Client Component.
@@ -49,12 +50,14 @@ export class CreateClientComponent {
    * @param {Router} router Router
    * @param {ClientsService} clientsService Clients Service
    * @param {SettingsService} settingsService Setting service
+   * @param {UserSyncService} userSyncService User sync service
    */
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private clientsService: ClientsService,
-    private settingsService: SettingsService
+    private settingsService: SettingsService,
+    private userSyncService: UserSyncService
   ) {
     this.route.data.subscribe((data: { clientTemplate: any; clientAddressFieldConfig: any }) => {
       this.clientTemplate = data.clientTemplate;
@@ -152,6 +155,9 @@ export class CreateClientComponent {
     }
 
     this.clientsService.createClient(clientData).subscribe((response: any) => {
+      console.log('Create Client Response:', response);
+      const country = this.settingsService.tenantIdentifier;
+      this.userSyncService.createKeycloakUser(clientData, response.resourceId, country).subscribe();
       this.router.navigate(
         [
           '../',

--- a/src/app/third-party/user-sync/user-sync.service.ts
+++ b/src/app/third-party/user-sync/user-sync.service.ts
@@ -36,6 +36,13 @@ export class UserSyncService {
   }
 
   /**
+   * Construct the full create endpoint for a new user.
+   */
+  private get CREATE_KEYCLOAK_USER_ENDPOINT(): string {
+    return `${this.BASE_URL}/keycloak/create/user`;
+  }
+
+  /**
    * Updates user details in Keycloak only if relevant fields have changed.
    * @param {any} newData New client data from the form.
    * @param {any} originalData Original client data before editing.
@@ -88,6 +95,45 @@ export class UserSyncService {
 
     const url = this.UPDATE_KEYCLOAK_USER_ENDPOINT(username);
     log.debug(`${logPrefix} updateKeycloakUser initiated for ${username}`);
+    log.debug(`${logPrefix} payload:`, payload);
+    log.debug(`${logPrefix} POST to:`, url);
+
+    return this.http.disableApiPrefix().post(url, payload);
+  }
+
+  /**
+   * Creates a user in Keycloak.
+   * @param {any} clientData Client data.
+   * @param {string} fineractId Fineract ID of the created client.
+   * @param {string} country Country (tenant identifier).
+   */
+  createKeycloakUser(clientData: any, fineractId: string, country: string) {
+    const logPrefix = '[user-sync.service::createKeycloakUser]';
+    log.debug(`${logPrefix} init`);
+
+    if (!environment.pushClientDataChangesToKeycloak) {
+      log.debug(`${logPrefix} pushClientDataChangesToKeycloak flag is disabled. Skipping synchronization.`);
+      return of(null);
+    }
+
+    const payload: any = {
+      username: clientData.emailAddress,
+      email: clientData.emailAddress,
+      firstName: clientData.firstname || clientData.fullname,
+      lastName: clientData.lastname,
+      phone: clientData.mobileNo,
+      fineract_id: fineractId,
+      country: country
+    };
+
+    const missingFields = Object.keys(payload).filter((key) => !payload[key]);
+    if (missingFields.length > 0) {
+      log.debug(`${logPrefix} Missing required fields: ${missingFields.join(', ')}. Skipping synchronization.`);
+      return of(null);
+    }
+
+    const url = this.CREATE_KEYCLOAK_USER_ENDPOINT;
+    log.debug(`${logPrefix} createKeycloakUser initiated for ${payload.username}`);
     log.debug(`${logPrefix} payload:`, payload);
     log.debug(`${logPrefix} POST to:`, url);
 

--- a/src/app/third-party/user-sync/user-sync.service.ts
+++ b/src/app/third-party/user-sync/user-sync.service.ts
@@ -119,8 +119,8 @@ export class UserSyncService {
     const payload: any = {
       username: clientData.emailAddress,
       email: clientData.emailAddress,
-      firstName: clientData.firstname || clientData.fullname,
-      lastName: clientData.lastname,
+      firstname: clientData.firstname || clientData.fullname,
+      lastname: clientData.lastname,
       phone: clientData.mobileNo,
       fineract_id: fineractId,
       country: country

--- a/src/app/third-party/user-sync/user-sync.service.ts
+++ b/src/app/third-party/user-sync/user-sync.service.ts
@@ -126,7 +126,15 @@ export class UserSyncService {
       country: country
     };
 
-    const missingFields = Object.keys(payload).filter((key) => !payload[key]);
+    const requiredFields = [
+      'username',
+      'email',
+      'firstname',
+      'lastname',
+      'fineract_id',
+      'country'
+    ];
+    const missingFields = requiredFields.filter((key) => !payload[key]);
     if (missingFields.length > 0) {
       log.debug(`${logPrefix} Missing required fields: ${missingFields.join(', ')}. Skipping synchronization.`);
       return of(null);


### PR DESCRIPTION
## Description
This branch implements the end-to-end workflow for synchronizing newly created clients in Mifos with Keycloak. The primary objective is to automate user identity creation and onboarding, ensuring that every new client registered in the backoffice platform has a corresponding authenticated account in the identity provider.

### Key Changes and Rationale
- Identity Automation: Added the `createKeycloakUser` workflow to the UserSyncService. This was done to move away from manual user creation in Keycloak, reducing administrative overhead and potential data mismatches between systems.
- Context-Aware Onboarding: Integrated the synchronization call into the CreateClientComponent. By capturing the tenantIdentifier from the SettingsService at the moment of creation, the system can now automatically assign users to country-specific groups in Keycloak (e.g., CLIENT_CHILE), facilitating localized permission management.
- Resilient Validation Pattern: Implemented strict validation both in the frontend and backend to ensure data integrity. Fields like firstname, lastname, and email are mandatory for identity creation, while phone has been made optional to accommodate different client registration requirements across regions.
- Onboarding Flow Initiation: The synchronization triggers a Keycloak verification email flow. This allows users to verify their identity and set their own passwords securely, rather than relying on temporary or system-generated passwords.
Documentation Alignment: Updated the integration guides to differentiate between "Client Create" (full identity creation) and "Client Update" (differential data sync) scenarios, providing clear technical requirements for both.

### Dependencies
1. User Sync Service (Backend): Requires the updated `POST /keycloak/create/user endpoint` and its associated Temporal.io worker.
2. Keycloak Instance: Access to the target realm with predefined country groups (formatted as `CLIENT_{COUNTRY_NAME}`) is necessary for successful organization assignment.
3. Environment Configuration: The `BELAT__USER_SYNC__PUSH_CLIENT_DATA_CHANGES_TO_KEYCLOAK` flag must be set to true to enable the synchronization logic.

## Related issues and discussion

[BELAT-1653](https://ginkofs.atlassian.net/browse/BELAT-1653)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
